### PR TITLE
ci: add node 16.x and 18.x to test strategies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ name: Build and test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, chore/add-node-tests ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ name: Build and test
 
 on:
   push:
-    branches: [ master, chore/add-node-tests ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
# Description

This PR adds to the test strategy the support to `Node 16.x` and `Node 18.x`.

# How
Added in `.github/workflows/build-and-test.yml` the node version `16.x` and `18.x`

# Test
A test has been performed in a different branch. [Here](https://github.com/musement/iso-duration/actions/runs/4076433342/jobs/7024160314) the result can be viewed.
Also, all the checks are visible in this MR.